### PR TITLE
Clear Meter Registry in MetricsIntegrationTests

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/test/MetricsIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/test/MetricsIntegrationTests.java
@@ -31,6 +31,7 @@ import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,6 +99,11 @@ class MetricsIntegrationTests {
 
 	@Autowired
 	private MeterRegistry registry;
+
+	@AfterEach
+	void cleanup() {
+		this.registry.clear();
+	}
 
 	@SuppressWarnings("unchecked")
 	@Test


### PR DESCRIPTION
The tests `org.springframework.boot.actuate.autoconfigure.metrics.test.MetricsIntegrationTests.restTemplateIsInstrumented` and `org.springframework.boot.actuate.autoconfigure.metrics.test.MetricsIntegrationTests.requestMappingIsInstrumented` are not idempotent and fail if run twice in the same JVM, because each of the tests pollutes some states shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by these tests.

### Detail
Running each of the aforementioned tests twice in the same JVM would result in the second run failing for assertions errors on the number of timers in the `MeterRegistry`, similar to the following:
```
org.junit.ComparisonFailure: 
Expected :1L
Actual   :2L
// failed at the following line:
assertThat(this.registry.get("http.client.requests").timer().count())
      .isEqualTo(1);
```
The root cause is that in each of the test runs, a timer is added to the `MeterRegistry`, which is not cleared when the test exits. Therefore, when the assertion is hit during the second test run, the number of timers in the `MeterRegistry` is 2 instead of 1, leading to the assertion error.

The suggested fix is to clear the `MeterRegistry` when each test exits.

The proposed fix resolves the issue of state pollution proactively before it causes other tests to fail.