### PR TITLE
Reset mockFilterInitialized in DelegatingFilterProxyRegistrationBeanT…

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/DelegatingFilterProxyRegistrationBeanTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/DelegatingFilterProxyRegistrationBeanTests.java
@@ -84,6 +84,7 @@ class DelegatingFilterProxyRegistrationBeanTests extends AbstractFilterRegistrat
 		assertThat(mockFilterInitialized.get()).isNull();
 		filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), new MockFilterChain());
 		assertThat(mockFilterInitialized.get()).isTrue();
+		mockFilterInitialized.remove();
 	}
 
 	@Test


### PR DESCRIPTION
The test `org.springframework.boot.web.servlet.DelegatingFilterProxyRegistrationBeanTests.initShouldNotCauseEarlyInitialization` is not idempotent and fails if run twice in the same JVM, because it pollutes a shared state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

### Detail
Running `DelegatingFilterProxyRegistrationBeanTests.initShouldNotCauseEarlyInitialization` twice in the same JVM would result in the second run failing for the following assertionr:
```
org.junit.ComparisonFailure: 
Expected :null
Actual   :true

// Failed at this line:
assertThat(mockFilterInitialized.get()).isNull();
```
The root cause is that in each of the test runs, the `ThreadLocal<Boolean> mockFilterInitialized` is set, which is not removed when the test exits. Therefore, when the assertion is hit during the second test run, `mockFilterInitialized` is still set(not `null`), leading to the assertion error.

The suggested fix is to remove the `mockFilterInitialized` when each test exits.

The proposed fix resolves the issue of state pollution proactively before it causes other tests to fail.